### PR TITLE
Update zipfile link in the readme to `all-layers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Uses OSX's built-in spelling features and dictionary to do this.
 Spell check isn't available for all text layers at a time. If you're using sketch as a replacement for illustrator or inDesign, you really miss the ability to automatically spell check everything everywhere.
 
 ## Usage
-**To install it, simply [download the zip](https://github.com/ethology-co/sketch-spellcheck-whole-page/archive/master.zip) and double-click the “.sketchplugin” file.** You can access the plugin via the plugins menu. You’ll know its worked when you see the notification at the bottom of the screen.
+**To install it, simply [download the zip](https://github.com/ethology-co/sketch-spellcheck-all-layers/archive/master.zip) and double-click the “.sketchplugin” file.** You can access the plugin via the plugins menu. You’ll know its worked when you see the notification at the bottom of the screen.
 
 Here’s a screen capture of the plugin in action:
 


### PR DESCRIPTION
It seems like you meant to change the github repo name to spellcheck-all-pages, but for the time being the link will still work. Cheers and thank you for building this!